### PR TITLE
fix: parse cookie timestamp

### DIFF
--- a/floki/cookie/cookie.mojo
+++ b/floki/cookie/cookie.mojo
@@ -9,6 +9,7 @@ from floki.cookie.duration import Duration
 struct Cookie(Copyable, Writable):
     """Represents an HTTP cookie with its attributes and provides methods for constructing, manipulating, and serializing cookies.
     """
+
     comptime EXPIRES = "Expires"
     """The `Expires` attribute of a cookie, indicating the expiration date and time of the cookie.
     """
@@ -87,17 +88,17 @@ struct Cookie(Copyable, Writable):
         self.partitioned = partitioned
 
     fn __init__[origin: Origin, //](out self, header: StringSlice[origin]) raises:
-        """Constructs a Cookie by parsing a tab-separated cookie header string.
+        """Constructs a Cookie by parsing a tab-separated libcurl cookie-list string.
 
         Parameters:
             origin: The origin of the StringSlice.
 
         Args:
-            header: A tab-separated string containing cookie fields
+            header: A tab-separated libcurl cookie-list string containing cookie fields
                     (domain, partitioned, path, secure, expires, name, value).
 
         Raises:
-            Error: If the header string cannot be parsed.
+            Error: If the cookie-list string cannot be parsed.
         """
         var raw_parts = header.split("\t")
         var parts: List[StringSlice[origin].Immutable] = [part for part in raw_parts]
@@ -105,10 +106,11 @@ struct Cookie(Copyable, Writable):
         self.partitioned = parts[1] == "TRUE"
         self.path = String(parts[2])
         self.secure = parts[3] == "TRUE"
-        self.expires = Expiration(parts[4])
+        # libcurl cookie-list expiration is a Unix timestamp in seconds, or 0 for session cookies.
+        self.expires = Expiration.from_libcurl_expires(parts[4])
         self.name = String(parts[5])
         self.value = String(parts[6])
-    
+
     fn write_to(self, mut writer: Some[Writer]):
         """Writes a debug representation of the cookie to a writer.
 
@@ -170,4 +172,3 @@ struct Cookie(Copyable, Writable):
     # fn is_expired(self, now: SmallTime) -> Bool:
     #     if self.expires.is_datetime():
     #         return self.expires.datetime.value() <= now
-    

--- a/floki/cookie/expiration.mojo
+++ b/floki/cookie/expiration.mojo
@@ -1,5 +1,5 @@
 from small_time import SmallTime, TimeZone
-from small_time.small_time import parse_time_with_format
+from small_time.small_time import from_timestamp, parse_time_with_format
 
 
 comptime HTTP_DATE_FORMAT = "ddd, DD MMM YYYY HH:mm:ss ZZZ"
@@ -7,8 +7,10 @@ comptime HTTP_DATE_FORMAT = "ddd, DD MMM YYYY HH:mm:ss ZZZ"
 
 
 @fieldwise_init
-struct Expiration(Copyable, Equatable, Defaultable):
-    """Represents the expiration setting for a cookie, which can be either session-scoped (no explicit expiry) or a specific datetime. Provides methods for constructing, comparing, and formatting expiration values."""
+struct Expiration(Copyable, Defaultable, Equatable):
+    """Represents the expiration setting for a cookie, which can be either session-scoped (no explicit expiry) or a specific datetime. Provides methods for constructing, comparing, and formatting expiration values.
+    """
+
     var variant: UInt8
     """An internal variant discriminator to determine if this is a session expiration (variant 0) or a datetime expiration (variant 1)."""
     var datetime: Optional[SmallTime]
@@ -29,7 +31,7 @@ struct Expiration(Copyable, Equatable, Defaultable):
         self.datetime = time
 
     fn __init__(out self, text: StringSlice) raises:
-        """Constructs an Expiration by parsing a date string.
+        """Constructs an Expiration by parsing an HTTP date string.
 
         Args:
             text: The string representation of the expiration date, or "0" for session-scoped.
@@ -42,6 +44,25 @@ struct Expiration(Copyable, Equatable, Defaultable):
             self.datetime = None
         else:
             self = Self(time=parse_time_with_format(text, HTTP_DATE_FORMAT, TimeZone.UTC))
+
+    @staticmethod
+    fn from_libcurl_expires(text: StringSlice) raises -> Self:
+        """Constructs an Expiration from libcurl's cookie-list expires field.
+
+        Args:
+            text: The libcurl cookie-list expiration value, either "0" for a session cookie or a Unix
+                timestamp in seconds.
+
+        Returns:
+            An Expiration parsed from the libcurl expires value.
+
+        Raises:
+            Error: If the timestamp cannot be parsed into a valid date.
+        """
+        var expires_timestamp = atol(text)
+        if expires_timestamp == 0:
+            return Self()
+        return Self(from_timestamp(Float64(expires_timestamp), utc=True))
 
     @staticmethod
     fn invalidate() -> Self:
@@ -73,7 +94,7 @@ struct Expiration(Copyable, Equatable, Defaultable):
 
         Returns:
             The formatted date string, or None if no datetime is set.
-        
+
         Raises:
             Error: If the datetime is not valid.
         """

--- a/pixi.lock
+++ b/pixi.lock
@@ -7,6 +7,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.modular.com/max/
     - url: https://prefix.dev/pixi-build-backends/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -24,7 +26,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
@@ -87,7 +89,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.20.0-hc57f145_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.5-hfae3067_0.conda
@@ -147,7 +149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.19.0-hd5a2499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
@@ -197,6 +199,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.modular.com/max/
     - url: https://prefix.dev/pixi-build-backends/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -220,7 +224,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
@@ -296,7 +300,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.20.0-hc57f145_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.5-hfae3067_0.conda
@@ -369,7 +373,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.19.0-hd5a2499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
@@ -570,29 +574,35 @@ packages:
   version: 0.1.0
   build: h60d57d3_0
   subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
   depends:
   - libcxx >=22
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   channel: null
 - conda: git+https://github.com/thatstoasty/mojo-curl?subdirectory=shim&tag=v0.2.1#208375ad90f61975e474ed4e9f985a5ddf6c2fa1
   name: curl_wrapper
   version: 0.1.0
   build: hb0f4dca_0
   subdir: linux-64
+  variants:
+    target_platform: linux-64
   depends:
   - libstdcxx >=15
   - libgcc >=15
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   channel: null
 - conda: git+https://github.com/thatstoasty/mojo-curl?subdirectory=shim&tag=v0.2.1#208375ad90f61975e474ed4e9f985a5ddf6c2fa1
   name: curl_wrapper
   version: 0.1.0
   build: he8cfe8b_0
   subdir: linux-aarch64
+  variants:
+    target_platform: linux-aarch64
   depends:
   - libstdcxx >=15
   - libgcc >=15
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   channel: null
 - conda: https://repo.prefix.dev/modular-community/linux-64/emberjson-0.3.1-hb0f4dca_0.conda
   sha256: 58c9da88a2443fe1ae8f38a8730248bafc7783e9dee2026fb6b0a38bfd434ca2
@@ -813,52 +823,52 @@ packages:
   license_family: GPL
   size: 875596
   timestamp: 1774197520746
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
-  sha256: a0390fd0536ebcd2244e243f5f00ab8e76ab62ed9aa214cd54470fe7496620f4
-  md5: d50608c443a30c341c24277d28290f76
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+  md5: c3cc2864f82a944bc90a7beb4d3b0e88
   depends:
   - __glibc >=2.17,<3.0.a0
   - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
-  - libnghttp2 >=1.67.0,<2.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 466704
-  timestamp: 1773218522665
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
-  sha256: 75c1b2f9cff7598c593dda96c55963298bebb5bcb5a77af0b4c41cb03d26100b
-  md5: d5306c7ec07faf48cfb0e552c67339e0
+  size: 468706
+  timestamp: 1777461492876
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.20.0-hc57f145_0.conda
+  sha256: 1607d3caf58f7d9e9ad9e5f0841737d0cfa47b5501d4e36fbf98e1c645d7393e
+  md5: 88da514c8db1a7f6a05297941a897af2
   depends:
   - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
-  - libnghttp2 >=1.67.0,<2.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 485694
-  timestamp: 1773218484057
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.19.0-hd5a2499_0.conda
-  sha256: c4d581b067fa60f9dc0e1c5f18b756760ff094a03139e6b206eb98d185ae2bb1
-  md5: 9fc7771fc8104abed9119113160be15a
+  size: 488942
+  timestamp: 1777461485901
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+  md5: 2f57b7d0c6adda88957586b7afd78438
   depends:
   - __osx >=11.0
   - krb5 >=1.22.2,<1.23.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
   - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 399616
-  timestamp: 1773219210246
+  size: 400568
+  timestamp: 1777462251987
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
   sha256: d1402087c8792461bfc081629e8aa97e6e577a31ae0b84e6b9cc144a18f48067
   md5: 4280e0a7fd613b271e022e60dea0138c
@@ -1392,10 +1402,12 @@ packages:
   version: 0.2.1
   build: h60d57d3_0
   subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
   depends:
   - mojo-compiler >=0.26.2.0,<0.26.3.0
   - libcurl >=8.17.0,<9.0.0
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   - curl_wrapper
   channel: null
   sources:
@@ -1406,10 +1418,12 @@ packages:
   version: 0.2.1
   build: hb0f4dca_0
   subdir: linux-64
+  variants:
+    target_platform: linux-64
   depends:
   - mojo-compiler >=0.26.2.0,<0.26.3.0
   - libcurl >=8.17.0,<9.0.0
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   - curl_wrapper
   channel: null
   sources:
@@ -1420,10 +1434,12 @@ packages:
   version: 0.2.1
   build: he8cfe8b_0
   subdir: linux-aarch64
+  variants:
+    target_platform: linux-aarch64
   depends:
   - mojo-compiler >=0.26.2.0,<0.26.3.0
   - libcurl >=8.17.0,<9.0.0
-  - libcurl >=8.19.0,<9.0a0
+  - libcurl >=8.20.0,<9.0a0
   - curl_wrapper
   channel: null
   sources:

--- a/test/test_cookie.mojo
+++ b/test/test_cookie.mojo
@@ -1,0 +1,23 @@
+from std.testing import TestSuite, assert_equal, assert_true
+from floki.cookie.expiration import Expiration
+
+
+fn test_libcurl_session_expiration() raises -> None:
+    var expires = Expiration.from_libcurl_expires("0")
+    assert_true(expires.is_session())
+
+
+fn test_libcurl_timestamp_expiration() raises -> None:
+    var expires = Expiration.from_libcurl_expires("1893456000")
+    assert_true(expires.is_datetime())
+    var expires_datetime = expires.datetime.value()
+    assert_equal(expires_datetime.year, 2030)
+    assert_equal(expires_datetime.month, 1)
+    assert_equal(expires_datetime.day, 1)
+    assert_equal(expires_datetime.hour, 0)
+    assert_equal(expires_datetime.minute, 0)
+    assert_equal(expires_datetime.second, 0)
+
+
+fn main() raises -> None:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/test/test_session.mojo
+++ b/test/test_session.mojo
@@ -3,6 +3,7 @@ from std.testing import TestSuite, assert_equal, assert_true
 import emberjson
 from floki.session import Session
 from floki.http import Status
+from floki.cookie.cookie import Cookie
 from floki.cookie.cookie_jar import CookieKey
 
 
@@ -179,6 +180,20 @@ fn test_cookie_parsing() raises -> None:
     )
     assert_equal(response.status, Status.OK)
     assert_equal(response.cookies[CookieKey("freeform", "httpbin.org", path="/")].value, "my_val")
+
+
+fn test_cookie_parsing_with_expiration() raises -> None:
+    var cookie = Cookie("httpbin.org\tFALSE\t/\tFALSE\t1893456000\tfreeform\tmy_val")
+    assert_equal(cookie.name, "freeform")
+    assert_equal(cookie.value, "my_val")
+    assert_true(cookie.expires.is_datetime())
+    var expires = cookie.expires.datetime.value()
+    assert_equal(expires.year, 2030)
+    assert_equal(expires.month, 1)
+    assert_equal(expires.day, 1)
+    assert_equal(expires.hour, 0)
+    assert_equal(expires.minute, 0)
+    assert_equal(expires.second, 0)
 
 
 fn main() raises -> None:


### PR DESCRIPTION
https://curl.se/docs/http-cookies.html

Field 4 is either an epoch, or 0. This correctly handles that. 

AI was used in parts (but not all) of this PR. 